### PR TITLE
Add looping over indexed axis trees

### DIFF
--- a/pyop3/__init__.py
+++ b/pyop3/__init__.py
@@ -11,11 +11,13 @@ from pyop3.axis import Axis, AxisComponent, AxisTree  # noqa: F401
 from pyop3.distarray import MultiArray  # noqa: F401
 from pyop3.dtypes import IntType, ScalarType  # noqa: F401
 from pyop3.index import (  # noqa: F401
+    AffineSliceComponent,
     Index,
     IndexTree,
     Map,
     Slice,
     SliceComponent,
+    SplitLoopIndex,
     TabulatedMapComponent,
 )
 from pyop3.loopexpr import (  # noqa: F401

--- a/pyop3/axis.py
+++ b/pyop3/axis.py
@@ -552,6 +552,9 @@ class Axis(LabelledNode):
         # dead code, remove
         self.indexed = False
 
+    def __getitem__(self, indices):
+        return as_axis_tree(self)[indices]
+
     def __str__(self) -> str:
         return f"{self.__class__.__name__}([{', '.join(str(cpt) for cpt in self.components)}], label={self.label})"
 
@@ -612,12 +615,8 @@ class AxisTree(LabelledTree):
         return dmap
 
     @property
-    def part(self):
-        try:
-            (pt,) = self.parts
-            return pt
-        except ValueError:
-            raise RuntimeError
+    def target_paths(self):
+        return tuple(self.path(ax, cpt) for ax, cpt in self.leaves)
 
     @functools.cached_property
     def layouts(self):

--- a/pyop3/axis.py
+++ b/pyop3/axis.py
@@ -559,6 +559,10 @@ class Axis(LabelledNode):
         return f"{self.__class__.__name__}([{', '.join(str(cpt) for cpt in self.components)}], label={self.label})"
 
     @property
+    def target_paths(self):
+        return tuple(pmap({self.label: cpt.label}) for cpt in self.components)
+
+    @property
     def count(self):
         """Return the total number of entries in the axis across all axis parts.
         Will fail if axis parts do not have integer counts.

--- a/pyop3/axis.py
+++ b/pyop3/axis.py
@@ -563,6 +563,10 @@ class Axis(LabelledNode):
         return tuple(pmap({self.label: cpt.label}) for cpt in self.components)
 
     @property
+    def size(self):
+        return as_axis_tree(self).size
+
+    @property
     def count(self):
         """Return the total number of entries in the axis across all axis parts.
         Will fail if axis parts do not have integer counts.

--- a/pyop3/axis.py
+++ b/pyop3/axis.py
@@ -586,11 +586,22 @@ class AxisTree(LabelledTree):
 
         self._layouts = {}
 
+    def __getitem__(self, indices):
+        from pyop3.index import IndexedAxisTree
+
+        return IndexedAxisTree(self, indices)
+
     def index(self):
         # cyclic import
         from pyop3.index import LoopIndex
 
         return LoopIndex(self)
+
+    def enumerate(self):
+        # cyclic import
+        from pyop3.index import EnumeratedLoopIndex
+
+        return EnumeratedLoopIndex(self)
 
     @functools.cached_property
     def datamap(self) -> dict[str:DistributedArray]:

--- a/pyop3/codegen/loopexpr2loopy.py
+++ b/pyop3/codegen/loopexpr2loopy.py
@@ -1118,7 +1118,7 @@ def _(slice_: Slice, *, codegen_ctx, prev_axes, **kwargs):
 
         if isinstance(subslice, AffineSliceComponent):
             jname_expr = pym.var(jname) * subslice.step + subslice.start
-            insns_per_leaf.append([])
+            insns_per_leaf.append(())
         else:
             assert isinstance(subslice, Subset)
             # subsets must be 1D, single component arrays

--- a/pyop3/codegen/loopexpr2loopy.py
+++ b/pyop3/codegen/loopexpr2loopy.py
@@ -1472,7 +1472,8 @@ def _(called_map: SplitCalledMap, **kwargs):
         components = []
         (from_path,) = leaf
 
-        bits = called_map.bits[pmap(from_path)]
+        # clean this up, we know some of this at an earlier point (loop context)
+        bits = called_map.map.map.bits[pmap(from_path)]
         for map_component in bits:  # each one of these is a new "leaf"
             cpt = AxisComponent(map_component.arity, label=map_component.label)
             components.append(cpt)

--- a/pyop3/distarray/multiarray.py
+++ b/pyop3/distarray/multiarray.py
@@ -22,8 +22,8 @@ from pyop3.dtypes import IntType, ScalarType, get_mpi_dtype
 from pyop3.index import (
     Indexed,
     IndexTree,
-    IndexTreeBag,
-    as_index_tree,
+    SplitIndexTree,
+    as_split_index_tree,
     is_fully_indexed,
 )
 from pyop3.utils import (
@@ -313,9 +313,7 @@ class MultiArray(DistributedArray, pym.primitives.Variable):
 
     # maybe I could check types here and use instead of get_value?
     def __getitem__(self, indices: IndexTree | Index):
-        # indices = as_index_tree(indices, self.axes)
-        if not isinstance(indices, IndexTreeBag):
-            raise NotImplementedError("TODO nice parsing")
+        indices = as_split_index_tree(indices, axes=self.axes)
 
         # TODO recover this
         # if not is_fully_indexed(self.axes, indices):

--- a/pyop3/distarray/multiarray.py
+++ b/pyop3/distarray/multiarray.py
@@ -19,7 +19,13 @@ from pyop3 import utils
 from pyop3.axis import Axis, AxisComponent, AxisTree, as_axis_tree, get_bottom_part
 from pyop3.distarray.base import DistributedArray
 from pyop3.dtypes import IntType, ScalarType, get_mpi_dtype
-from pyop3.index import Indexed, IndexTree, as_index_tree, is_fully_indexed
+from pyop3.index import (
+    Indexed,
+    IndexTree,
+    IndexTreeBag,
+    as_index_tree,
+    is_fully_indexed,
+)
 from pyop3.utils import (
     PrettyTuple,
     as_tuple,
@@ -307,10 +313,13 @@ class MultiArray(DistributedArray, pym.primitives.Variable):
 
     # maybe I could check types here and use instead of get_value?
     def __getitem__(self, indices: IndexTree | Index):
-        indices = as_index_tree(indices, self.axes)
+        # indices = as_index_tree(indices, self.axes)
+        if not isinstance(indices, IndexTreeBag):
+            raise NotImplementedError("TODO nice parsing")
 
-        if not is_fully_indexed(self.axes, indices):
-            raise ValueError("Provided indices are insufficient to address the array")
+        # TODO recover this
+        # if not is_fully_indexed(self.axes, indices):
+        #     raise ValueError("Provided indices are insufficient to address the array")
 
         return Indexed(self, indices)
 

--- a/pyop3/index.py
+++ b/pyop3/index.py
@@ -136,6 +136,10 @@ class AffineSliceComponent(SliceComponent):
         self.stop = stop
         self.step = step if step is not None else 1
 
+    @property
+    def datamap(self):
+        return {}
+
 
 class Subset(SliceComponent):
     fields = SliceComponent.fields | {"array"}
@@ -143,6 +147,10 @@ class Subset(SliceComponent):
     def __init__(self, component, array: MultiArray):
         super().__init__(component)
         self.array = array
+
+    @property
+    def datamap(self):
+        return self.array.datamap
 
 
 class MapComponent(LabelledImmutableRecord):
@@ -329,8 +337,7 @@ class Slice(Index):
 
     @property
     def datamap(self):
-        # return pmap()
-        return {}
+        return merge_dicts([s.datamap for s in self.slices])
 
 
 class SplitCalledMap(Index):

--- a/pyop3/loopexpr.py
+++ b/pyop3/loopexpr.py
@@ -14,7 +14,7 @@ import numpy as np
 import pytools
 
 from pyop3.distarray import DistributedArray, MultiArray
-from pyop3.index import Indexed, as_index_tree
+from pyop3.index import EnumeratedLoopIndex, Indexed, as_index_tree
 from pyop3.utils import as_tuple, checked_zip, merge_dicts
 
 
@@ -79,6 +79,10 @@ class Loop(LoopExpr):
             id = self.id_generator("loop")
 
         super().__init__()
+
+        if isinstance(index, EnumeratedLoopIndex):
+            index = index.index
+
         self.index = index
         self.statements = as_tuple(statements)
         self.id = id

--- a/pyop3/loopexpr.py
+++ b/pyop3/loopexpr.py
@@ -14,7 +14,7 @@ import numpy as np
 import pytools
 
 from pyop3.distarray import DistributedArray, MultiArray
-from pyop3.index import EnumeratedLoopIndex, Indexed, as_index_tree
+from pyop3.index import EnumeratedLoopIndex, Indexed
 from pyop3.utils import as_tuple, checked_zip, merge_dicts
 
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,21 @@
+import loopy as lp
+import pytest
+
+from pyop3 import READ, WRITE, LoopyKernel, ScalarType
+from pyop3.codegen import LOOPY_LANG_VERSION, LOOPY_TARGET
+
+
+@pytest.fixture
+def scalar_copy_kernel():
+    code = lp.make_kernel(
+        "{ [i]: 0 <= i < 1 }",
+        "y[i] = x[i]",
+        [
+            lp.GlobalArg("x", ScalarType, (1,), is_input=True, is_output=False),
+            lp.GlobalArg("y", ScalarType, (1,), is_input=False, is_output=True),
+        ],
+        name="scalar_copy",
+        target=LOOPY_TARGET,
+        lang_version=LOOPY_LANG_VERSION,
+    )
+    return LoopyKernel(code, [READ, WRITE])

--- a/tests/integration/test_basics.py
+++ b/tests/integration/test_basics.py
@@ -12,7 +12,7 @@ from pyop3.distarray import MultiArray
 from pyop3.dtypes import IntType, ScalarType
 
 # ultimately shouldn't be needed here
-from pyop3.index import Index, IndexTree, IndexTreeBag, Slice
+from pyop3.index import AffineSliceComponent, Index, IndexTree, Slice, SplitIndexTree
 from pyop3.loopexpr import INC, READ, WRITE, LoopyKernel, do_loop, loop
 from pyop3.utils import flatten
 
@@ -64,12 +64,7 @@ def test_scalar_copy(scalar_copy_kernel):
         dtype=dat0.dtype,
     )
 
-    # for now, need to clean up API
-    p = axis.index()
-    itree_bag = IndexTreeBag(pmap({pmap({p: pmap({"ax0": "pt0"})}): IndexTree(p)}))
-
-    # do_loop(p := axis.index(), scalar_copy_kernel(dat0[p], dat1[p]))
-    do_loop(p, scalar_copy_kernel(dat0[itree_bag], dat1[itree_bag]))
+    do_loop(p := axis.index(), scalar_copy_kernel(dat0[p], dat1[p]))
     assert np.allclose(dat1.data, dat0.data)
 
 
@@ -101,9 +96,9 @@ def test_multi_component_vector_copy(vector_copy_kernel):
     m, n, a, b = 4, 6, 2, 3
 
     axes = AxisTree(
-        root := Axis([(m, "cpt0"), (n, "cpt1")], "ax0"),
+        Axis([AxisComponent(m, "pt0"), AxisComponent(n, "pt1")], "ax0", id="root"),
         {
-            root.id: [
+            "root": [
                 Axis(a),
                 Axis(b),
             ]
@@ -123,8 +118,12 @@ def test_multi_component_vector_copy(vector_copy_kernel):
     # TODO It would be nice to express this as a loop over
     # p := axes.root[Slice(axis="ax0", cpt=1)].index
     # but this needs axis slicing to work first.
-    iterset = Axis([(n, "cpt1")], "ax0")
-    do_loop(p := iterset.index(), vector_copy_kernel(dat0[p, :], dat1[p, :]))
+    # iterset = Axis([(n, "cpt1")], "ax0")
+    # do_loop(p := iterset.index(), vector_copy_kernel(dat0[p, :], dat1[p, :]))
+    do_loop(
+        p := axes.root[Slice("ax0", [AffineSliceComponent("pt1")])].index(),
+        vector_copy_kernel(dat0[p, :], dat1[p, :]),
+    )
 
     assert all(dat1.data[: m * a] == 0)
     assert all(dat1.data[m * a :] == dat0.data[m * a :])

--- a/tests/integration/test_basics.py
+++ b/tests/integration/test_basics.py
@@ -115,11 +115,6 @@ def test_multi_component_vector_copy(vector_copy_kernel):
         dtype=dat0.dtype,
     )
 
-    # TODO It would be nice to express this as a loop over
-    # p := axes.root[Slice(axis="ax0", cpt=1)].index
-    # but this needs axis slicing to work first.
-    # iterset = Axis([(n, "cpt1")], "ax0")
-    # do_loop(p := iterset.index(), vector_copy_kernel(dat0[p, :], dat1[p, :]))
     do_loop(
         p := axes.root[Slice("ax0", [AffineSliceComponent("pt1")])].index(),
         vector_copy_kernel(dat0[p, :], dat1[p, :]),

--- a/tests/integration/test_local_indices.py
+++ b/tests/integration/test_local_indices.py
@@ -1,0 +1,36 @@
+import numpy as np
+
+from pyop3 import Axis, AxisTree, MultiArray, ScalarType, do_loop
+
+
+def test_copy_with_local_indices(scalar_copy_kernel):
+    size = 10
+    axes = AxisTree(Axis(size))
+    dat0 = MultiArray(axes, data=np.arange(axes.size, dtype=ScalarType))
+    dat1 = MultiArray(axes, dtype=dat0.dtype)
+
+    do_loop(p := axes.enumerate(), scalar_copy_kernel(dat0[p.index], dat1[p.count]))
+    assert np.allclose(dat1.data, dat0.data)
+
+
+def test_inc_into_small_array(scalar_copy_kernel):
+    size = 10
+    dim = 3
+
+    big = MultiArray(big_axes)
+    small = MultiArray(small_axes)
+
+    # The following is equivalent to
+    # for p in big_axes.root:
+    #   for i, q in enumerate(big_axes[p]):
+    #     small[i] = big[p, q]
+    do_loop(
+        p := big_axes.root.index(),
+        loop(
+            # NOTE: This could be a namedtuple to make things clearer
+            q := big_axes[p, :].enumerate(),
+            scalar_copy_kernel(big[p, q[1]], small[q[0]]),
+        ),
+    )
+
+    assert False, "TODO"

--- a/tests/integration/test_local_indices.py
+++ b/tests/integration/test_local_indices.py
@@ -1,6 +1,10 @@
 import numpy as np
+import pytest
 
 from pyop3 import Axis, AxisTree, MultiArray, ScalarType, do_loop
+
+# TODO
+pytest.skip(allow_module_level=True)
 
 
 def test_copy_with_local_indices(scalar_copy_kernel):

--- a/tests/integration/test_maps.py
+++ b/tests/integration/test_maps.py
@@ -28,22 +28,6 @@ from pyop3.utils import flatten
 
 
 @pytest.fixture
-def scalar_copy_kernel():
-    code = lp.make_kernel(
-        "{ [i]: 0 <= i < 1 }",
-        "y[i] = x[i]",
-        [
-            lp.GlobalArg("x", ScalarType, (1,), is_input=True, is_output=False),
-            lp.GlobalArg("y", ScalarType, (1,), is_input=False, is_output=True),
-        ],
-        target=LOOPY_TARGET,
-        name="scalar_copy",
-        lang_version=(2018, 2),
-    )
-    return LoopyKernel(code, [READ, WRITE])
-
-
-@pytest.fixture
 def vector_inc_kernel():
     lpy_kernel = lp.make_kernel(
         "{ [i]: 0 <= i < 3 }",

--- a/tests/integration/test_slice_composition.py
+++ b/tests/integration/test_slice_composition.py
@@ -10,7 +10,7 @@ from pyop3.axis import Axis, AxisComponent, AxisTree
 from pyop3.codegen import LOOPY_LANG_VERSION, LOOPY_TARGET
 from pyop3.distarray import MultiArray
 from pyop3.dtypes import IntType, ScalarType
-from pyop3.index import IndexTree, Slice, SliceComponent
+from pyop3.index import AffineSliceComponent, IndexTree, Slice
 from pyop3.loopexpr import INC, READ, WRITE, LoopyKernel, do_loop, loop
 from pyop3.utils import flatten
 
@@ -43,7 +43,7 @@ def test_1d_slice_composition(vec2_copy_kernel):
 
     # this is needed because we currently do not compute the axis tree for the
     # intermediate indexed object, so it cannot be indexed with shorthand
-    itree = IndexTree(Slice("ax0", [SliceComponent("cpt0", 1, 3)]))
+    itree = IndexTree(Slice("ax0", [AffineSliceComponent("cpt0", 1, 3)]))
 
     # do_loop(Axis(1).index(), vec2_copy_kernel(dat0[::2][1:3], dat1[...]))
     do_loop(Axis(1).index(), vec2_copy_kernel(dat0[::2][itree], dat1[...]))
@@ -63,8 +63,8 @@ def test_2d_slice_composition(vec2_copy_kernel):
     dat1 = MultiArray(axes1, name="dat1", dtype=dat0.dtype)
 
     itree = IndexTree(
-        Slice("ax0", [SliceComponent("cpt0", 2, 4)], id="slice1"),
-        {"slice1": Slice("ax1", [SliceComponent("cpt0", 1, 2)])},
+        Slice("ax0", [AffineSliceComponent("cpt0", 2, 4)], id="slice1"),
+        {"slice1": Slice("ax1", [AffineSliceComponent("cpt0", 1, 2)])},
     )
 
     do_loop(

--- a/tests/integration/test_subsets.py
+++ b/tests/integration/test_subsets.py
@@ -24,7 +24,7 @@ from pyop3 import (
     loop,
 )
 from pyop3.codegen import LOOPY_LANG_VERSION, LOOPY_TARGET
-from pyop3.index import AffineSliceComponent, IndexTreeBag, UnrolledLoopIndex
+from pyop3.index import AffineSliceComponent, SplitIndexTree, SplitLoopIndex
 from pyop3.utils import flatten
 
 
@@ -37,12 +37,12 @@ def test_loop_over_slices(scalar_copy_kernel):
     dat1 = MultiArray(axes, name="dat1", dtype=dat0.dtype)
 
     # cleanup
-    itreebag0 = IndexTreeBag(
+    itreebag0 = SplitIndexTree(
         pmap({pmap(): IndexTree(Slice("ax0", [AffineSliceComponent("pt0", start=2)]))})
     )
     p = axes[itreebag0].index()
-    unrolled_p = UnrolledLoopIndex(p, pmap({"ax0": "pt0"}))
-    itree_bag = IndexTreeBag(
+    unrolled_p = SplitLoopIndex(p, pmap({"ax0": "pt0"}))
+    itree_bag = SplitIndexTree(
         pmap({pmap({p: pmap({"ax0": "pt0"})}): IndexTree(unrolled_p)})
     )
 

--- a/tests/integration/test_subsets.py
+++ b/tests/integration/test_subsets.py
@@ -47,22 +47,18 @@ def test_loop_over_slices(scalar_copy_kernel, touched, untouched):
     assert np.allclose(dat1.data[touched], dat0.data[touched])
 
 
-def test_scalar_copy_of_subset(scalar_copy_kernel):
-    m, n = 6, 4
-    sdata = np.asarray([2, 3, 5, 0], dtype=IntType)
-    untouched = [1, 4]
+@pytest.mark.parametrize("size,touched", [(6, [2, 3, 5, 0])])
+def test_scalar_copy_of_subset(scalar_copy_kernel, size, touched):
+    untouched = list(set(range(size)) - set(touched))
+    subset_axes = Axis(len(touched))
+    subset = MultiArray(
+        subset_axes, name="subset0", data=np.asarray(touched, dtype=IntType)
+    )
 
-    axes = AxisTree(Axis([AxisComponent(m, "cpt0")], "ax0"))
+    axes = Axis(size)
     dat0 = MultiArray(axes, name="dat0", data=np.arange(axes.size, dtype=ScalarType))
     dat1 = MultiArray(axes, name="dat1", dtype=dat0.dtype)
 
-    # a subset is really a map from a small set into a larger one
-    saxes = AxisTree(
-        Axis([AxisComponent(n, "scpt0")], "sax0", id="root"), {"root": Axis(1)}
-    )
-    subset = MultiArray(saxes, name="subset0", data=sdata)
-
     do_loop(p := axes[subset].index(), scalar_copy_kernel(dat0[p], dat1[p]))
-
-    assert np.allclose(dat1.data[sdata], dat0.data[sdata])
+    assert np.allclose(dat1.data[touched], dat0.data[touched])
     assert np.allclose(dat1.data[untouched], 0)


### PR DESCRIPTION
Permit things like `loop(p := axes[::2].index(), ...)` and `loop(p := axes[subset].index(), ...)`.