### PR TITLE
Better slice composition

### DIFF
--- a/pyop3/distarray/multiarray.py
+++ b/pyop3/distarray/multiarray.py
@@ -126,6 +126,8 @@ class MultiArray(DistributedArray, pym.primitives.Variable):
 
         self._sync_thread = None
 
+    # don't like this, instead use something singledispatch in the right place
+    # split_axes is only used for a very specific use case
     @property
     def split_axes(self):
         return pmap({pmap(): self.axes})

--- a/pyop3/distarray/multiarray.py
+++ b/pyop3/distarray/multiarray.py
@@ -14,6 +14,7 @@ import pymbolic as pym
 import pytools
 from mpi4py import MPI
 from petsc4py import PETSc
+from pyrsistent import pmap
 
 from pyop3 import utils
 from pyop3.axis import Axis, AxisComponent, AxisTree, as_axis_tree, get_bottom_part
@@ -124,6 +125,10 @@ class MultiArray(DistributedArray, pym.primitives.Variable):
         self._halo_valid = True
 
         self._sync_thread = None
+
+    @property
+    def split_axes(self):
+        return pmap({pmap(): self.axes})
 
     @property
     def data(self):
@@ -313,12 +318,6 @@ class MultiArray(DistributedArray, pym.primitives.Variable):
 
     # maybe I could check types here and use instead of get_value?
     def __getitem__(self, indices: IndexTree | Index):
-        indices = as_split_index_tree(indices, axes=self.axes)
-
-        # TODO recover this
-        # if not is_fully_indexed(self.axes, indices):
-        #     raise ValueError("Provided indices are insufficient to address the array")
-
         return Indexed(self, indices)
 
     def select_axes(self, indices):

--- a/pyop3/index.py
+++ b/pyop3/index.py
@@ -84,8 +84,13 @@ class Indexed:
     """
 
     def __init__(self, obj, indices):
+        from pyop3.codegen.loopexpr2loopy import _indexed_axes
+
         self.obj = obj
-        self.indices = as_split_index_tree(indices)
+        self.indices = as_split_index_tree(indices, axes=self.obj.axes)
+
+        # for now
+        self.axes = _indexed_axes(self, pmap())
 
     # old alias, not right now we have a pmap of index trees rather than just a single one
     @property
@@ -93,16 +98,7 @@ class Indexed:
         return self.indices
 
     def __getitem__(self, indices):
-        from pyop3.distarray import MultiArray
-
-        if not isinstance(self.obj, MultiArray) and not isinstance(
-            indices, (IndexTree, Index)
-        ):
-            raise NotImplementedError(
-                "Need to compute the temporary/intermediate axes for this to be allowed"
-            )
-
-        indices = as_split_index_tree(indices)
+        indices = as_split_index_tree(indices, axes=self.axes)
         return Indexed(self, indices)
 
     @functools.cached_property

--- a/pyop3/index.py
+++ b/pyop3/index.py
@@ -4,6 +4,7 @@ import abc
 import collections
 import dataclasses
 import functools
+import numbers
 from typing import Any, Collection, Hashable, Mapping, Sequence
 
 import pytools
@@ -566,6 +567,12 @@ def _split_index_tree_from_iterable(
             ]
         elif isinstance(index, MultiArray):
             slice_cpts = [Subset(cpt.label, index) for cpt in current_axis.components]
+        elif isinstance(index, numbers.Integral):
+            # an integer is just a one-sized slice (assumed over all components)
+            slice_cpts = [
+                AffineSliceComponent(cpt.label, index, index + 1)
+                for cpt in current_axis.components
+            ]
         else:
             raise TypeError
         index = Slice(current_axis.label, slice_cpts)

--- a/tests/integration/test_nested_loops.py
+++ b/tests/integration/test_nested_loops.py
@@ -1,8 +1,26 @@
-def test_transpose():
-    # array0 = MultiArray(???)
-    # array0 = MultiArray(???)
+import numpy as np
+
+from pyop3 import Axis, AxisTree, MultiArray, ScalarType, do_loop, loop
+
+
+def test_transpose(scalar_copy_kernel):
+    npoints = 5
+    axis0 = Axis(npoints)
+    axis1 = Axis(npoints)
+
+    axes0 = AxisTree(axis0, {axis0.id: axis1})
+    axes1 = AxisTree(axis1, {axis1.id: axis0})
+
+    array0 = MultiArray(
+        axes0, name="array0", data=np.arange(axes0.size, dtype=ScalarType)
+    )
+    array1 = MultiArray(axes1, name="array1", dtype=array0.dtype)
 
     do_loop(
         p := axis0.index(),
         loop(q := axis1.index(), scalar_copy_kernel(array0[p, q], array1[q, p])),
+    )
+    assert np.allclose(
+        array1.data.reshape((npoints, npoints)),
+        array0.data.reshape((npoints, npoints)).T,
     )

--- a/tests/integration/test_nested_loops.py
+++ b/tests/integration/test_nested_loops.py
@@ -1,0 +1,8 @@
+def test_transpose():
+    # array0 = MultiArray(???)
+    # array0 = MultiArray(???)
+
+    do_loop(
+        p := axis0.index(),
+        loop(q := axis1.index(), scalar_copy_kernel(array0[p, q], array1[q, p])),
+    )

--- a/tests/integration/test_slice_composition.py
+++ b/tests/integration/test_slice_composition.py
@@ -57,16 +57,10 @@ def test_2d_slice_composition(vec2_copy_kernel):
     dat0 = MultiArray(axes0, name="dat0", data=np.arange(axes0.size, dtype=ScalarType))
     dat1 = MultiArray(axes1, name="dat1", dtype=dat0.dtype)
 
-    itree = IndexTree(
-        Slice("ax0", [AffineSliceComponent("cpt0", 2, 4)], id="slice1"),
-        {"slice1": Slice("ax1", [AffineSliceComponent("cpt0", 1, 2)])},
-    )
-
     do_loop(
         Axis(1).index(),
         vec2_copy_kernel(
-            # dat0[::2, 1:][2:4, 1],
-            dat0[::2, 1:][itree],
+            dat0[::2, 1:][2:4, 1],
             dat1[...],
         ),
     )

--- a/tests/integration/test_slice_composition.py
+++ b/tests/integration/test_slice_composition.py
@@ -41,12 +41,7 @@ def test_1d_slice_composition(vec2_copy_kernel):
     )
     dat1 = MultiArray(Axis([(n, "cpt0")], "ax0"), name="dat1", dtype=dat0.dtype)
 
-    # this is needed because we currently do not compute the axis tree for the
-    # intermediate indexed object, so it cannot be indexed with shorthand
-    itree = IndexTree(Slice("ax0", [AffineSliceComponent("cpt0", 1, 3)]))
-
-    # do_loop(Axis(1).index(), vec2_copy_kernel(dat0[::2][1:3], dat1[...]))
-    do_loop(Axis(1).index(), vec2_copy_kernel(dat0[::2][itree], dat1[...]))
+    do_loop(Axis(1).index(), vec2_copy_kernel(dat0[::2][1:3], dat1[...]))
     assert np.allclose(dat1.data, dat0.data[::2][1:3])
 
 


### PR DESCRIPTION
Get things like `dat[::2][1:]` working. This requires us to be able to inspect intermediate axis trees which is complicated since we have to be aware of the current loop context. The current approach is ugly but, I believe, correct.