### PR TITLE
Add local indexing and enumerate

### DIFF
--- a/pyop3/axis.py
+++ b/pyop3/axis.py
@@ -604,9 +604,9 @@ class AxisTree(LabelledTree):
 
     def index(self):
         # cyclic import
-        from pyop3.index import LoopIndex
+        from pyop3.index import GlobalLoopIndex
 
-        return LoopIndex(self)
+        return GlobalLoopIndex(self)
 
     def enumerate(self):
         # cyclic import

--- a/pyop3/loopexpr.py
+++ b/pyop3/loopexpr.py
@@ -81,7 +81,7 @@ class Loop(LoopExpr):
         super().__init__()
 
         if isinstance(index, EnumeratedLoopIndex):
-            index = index.index
+            index = index.global_index
 
         self.index = index
         self.statements = as_tuple(statements)


### PR DESCRIPTION
This adds the ability for us to write things like:

```
for i, x in enumerate(myarray):
    temp[i] = f(x)
```

I think that this should be useful for things like generic map tabulation (needed for PETSc matrices) since we need to write a series of loops that look like:

```py
loop(
  c := mesh.cells,
  loop(
    i, p := axes[closure(c)].enumerate(),
    map[c, i] = calc_offset(p)
  )
)
```